### PR TITLE
Fix: No mic on phone calls

### DIFF
--- a/audio/mixer_paths.xml
+++ b/audio/mixer_paths.xml
@@ -519,6 +519,9 @@
 		<ctl name="DEC6 Volume" value="100" />
 		<ctl name="ADC3 Volume" value="17" />
 		<ctl name="DEC4 Volume" value="100" />
+		<!-- Swap L/R channels -->
+		<ctl name="SLIM TX7 MUX" value="DEC4" />
+		<ctl name="SLIM TX8 MUX" value="DEC6" />
 	</path>
 
 	<path name="rec-high-gain-main-mic">

--- a/audio/mixer_paths.xml
+++ b/audio/mixer_paths.xml
@@ -383,11 +383,11 @@
 	<path name="main-sub-mic">
 		<ctl name="AIF1_CAP Mixer SLIM TX7" value="1" />
 		<ctl name="SLIM_0_TX Channels" value="Two" />
-		<ctl name="SLIM TX7 MUX" value="DEC4" />
-		<ctl name="DEC4 MUX" value="ADC3" />
-		<ctl name="AIF1_CAP Mixer SLIM TX8" value="1" />
-		<ctl name="SLIM TX8 MUX" value="DEC6" />
+		<ctl name="SLIM TX7 MUX" value="DEC6" />
 		<ctl name="DEC6 MUX" value="ADC1" />
+		<ctl name="AIF1_CAP Mixer SLIM TX8" value="1" />
+		<ctl name="SLIM TX8 MUX" value="DEC4" />
+		<ctl name="DEC4 MUX" value="ADC3" />
 	</path>
 
 	<path name="sub-3rd-mic">


### PR DESCRIPTION
Swapping L/R mic channels globally results in ES325 (noise cancellation chip) picking up the wrong channel cancelling the voice instead. This commit limits the mic swap to 'rec-stereo-mic' audio path.