### PR TITLE
Revert "ks01ltexx: Nuke deprecated WiFi Display overlay"

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -2,7 +2,6 @@
 <!--
 /*
 ** Copyright 2011, The Android Open Source Project
-** Copyright 2017-2019, The LineageOS Project
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -254,6 +253,8 @@
          1 - The device DOES have a permanent menu key; ignore autodetection.
          2 - The device DOES NOT have a permanent menu key; ignore autodetection. -->
     <integer name="config_overrideHasPermanentMenuKey">2</integer>
+
+    <bool name="config_enableWifiDisplay">true</bool>
 
     <!-- Configure wifi tcp buffersizes in the form:
          rmem_min,rmem_def,rmem_max,wmem_min,wmem_def,wmem_max -->


### PR DESCRIPTION
This reverts commit 7f29acf422c71c06453a65787c6e165f7df6c939.
Reason for revert: topic pie-aosp-wfd restored the functionality